### PR TITLE
Add pages workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -48,7 +48,7 @@ jobs:
 
       # publishes wwwroot directory to GitHub Pages
       - name: Commit wwwroot to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,55 @@
+name: Deploy to GitHub Pages
+
+# Adapted from: https://github.com/TenaciousDev/BlazorGitHubPagesDemo
+
+# Run workflow on every push to the main branch
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy-to-github-pages:
+    # use ubuntu-latest image to run steps on
+    runs-on: ubuntu-latest
+    steps:
+      # uses GitHub's checkout action to checkout code from the main branch
+      - uses: actions/checkout@v2
+
+      # sets up .NET SDK 9.0.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      # installs the Blake CLI
+      - name: Install Blake CLI
+        run: dotnet tool install -g Blake.CLI
+
+      # bake static content
+      - name: Run blake bake
+        run: blake bake
+
+      # publishes Blazor project to the release folder
+      - name: Publish .NET Project
+        run: dotnet publish -c Release -o release --nologo
+
+      # changes the base-tag in index.html from '/' to 'BlakeSimpleTailwindSample' to match GitHub Pages repository subdirectory
+      # TODO: Make this generic
+      - name: Change base-tag in index.html from / to BlakeSimpleTailwindSample
+        run: sed -i 's/<base href="\/" \/>/<base href="\/BlakeSimpleTailwindSample\/" \/>/g' release/wwwroot/index.html
+
+      # copy index.html to 404.html to serve the same file when a file is not found
+      - name: copy index.html to 404.html
+        run: cp release/wwwroot/index.html release/wwwroot/404.html
+
+      # add .nojekyll file to tell GitHub pages to not treat this as a Jekyll project. (Allow files and folders starting with an underscore)
+      - name: Add .nojekyll file
+        run: touch release/wwwroot/.nojekyll
+
+      # publishes wwwroot directory to GitHub Pages
+      - name: Commit wwwroot to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages # The branch the action should deploy to.
+          folder: release/wwwroot # The folder the action should deploy.

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # uses GitHub's checkout action to checkout code from the main branch
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # sets up .NET SDK 9.0.x
       - name: Setup .NET

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,10 +33,12 @@ jobs:
       - name: Publish .NET Project
         run: dotnet publish -c Release -o release --nologo
 
-      # changes the base-tag in index.html from '/' to 'BlakeSimpleTailwindSample' to match GitHub Pages repository subdirectory
-      # TODO: Make this generic
-      - name: Change base-tag in index.html from / to BlakeSimpleTailwindSample
-        run: sed -i 's/<base href="\/" \/>/<base href="\/BlakeSimpleTailwindSample\/" \/>/g' release/wwwroot/index.html
+      # changes the base-tag in index.html from '/' to the repository name to match GitHub Pages repository subdirectory
+      # This is now generic and works for any repository.
+      - name: Change base-tag in index.html from / to repository name
+        run: |
+          REPO_NAME="${{ github.event.repository.name }}"
+          sed -i "s|<base href=\"/\" />|<base href=\"/${REPO_NAME}/\" />|g" release/wwwroot/index.html
 
       # copy index.html to 404.html to serve the same file when a file is not found
       - name: copy index.html to 404.html

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run blake bake
         run: blake bake
 
-      # publishes Blazor project to the release folder
+      # publishes the Blake static site to the release folder
       - name: Publish .NET Project
         run: dotnet publish -c Release -o release --nologo
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 A clean and minimal starter template for building Markdown-powered blogs with the [Blake](https://github.com/matt-goldman/blake) static site generator.
 Styled with [Tailwind CSS](https://tailwindcss.com/) and ready to deploy.
 
+## Demo
+
+You can see a live demo of this template at [Blake Simple Tailwind Sample](https://matt-goldman.github.io/BlakeSimpleTailwindSample).
+
 ---
 
 ## ✨ Features
@@ -35,7 +39,6 @@ dotnet tool install -g Blake.CLI
    ```bash
    blake new --template tailwind-sample
    ```
-   
    (see Blake docs for more details on the `blake new` command)
 
    Alternatively, you can clone this repository directly:
@@ -110,13 +113,16 @@ blake-sample-blog/
 
 ## 📦 Deployment
 
-This template outputs static files. You can host the result anywhere that serves static sites, e.g.:
+This template includes a GitHub Actions workflow for deploying to GitHub Pages. The workflow is defined in `.github/workflows/deploy-pages.yml`, it builds and deploys the site automatically when you push to the main branch.
 
-* GitHub Pages
-* Azure Static Web Apps
+If you have cloned this repository, or created this with `blake new`, you can push to your GitHub repository and the workflow will handle the deployment as it integrates with GitHub Pages automatically. You will have to complete the following setup steps:
 
+1. Enable GitHub Pages in your repository settings.
+2. In the workflow file, ensure the `base` tag in `index.html` is set correctly for your repository name. The default is set to `BlakeSimpleTailwindSample`, but you can change it to match your repository name.
+3. Push your changes to the main branch.
+4. The GitHub Actions workflow will automatically build the site and deploy it to the `gh-pages` branch.
 
-Push to your main branch and GitHub Actions will automatically build and deploy.
+As a Blake site is just a static site, you can also deploy it to any static hosting service like Azure, Netlify, Vercel, Cloudflare, or even a simple web server. Most of these are free! 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -118,11 +118,10 @@ This template includes a GitHub Actions workflow for deploying to GitHub Pages. 
 If you have cloned this repository, or created this with `blake new`, you can push to your GitHub repository and the workflow will handle the deployment as it integrates with GitHub Pages automatically. You will have to complete the following setup steps:
 
 1. Enable GitHub Pages in your repository settings.
-2. In the workflow file, ensure the `base` tag in `index.html` is set correctly for your repository name. The default is set to `BlakeSimpleTailwindSample`, but you can change it to match your repository name.
-3. Push your changes to the main branch.
-4. The GitHub Actions workflow will automatically build the site and deploy it to the `gh-pages` branch.
+2. Push your changes to the main branch.
+3. The GitHub Actions workflow will automatically build the site and deploy it to the `gh-pages` branch.
 
-As a Blake site is just a static site, you can also deploy it to any static hosting service like Azure, Netlify, Vercel, Cloudflare, or even a simple web server. Most of these are free! 
+As a Blake site is just a static site, you can also deploy it to any static hosting service like Azure, Netlify, Vercel, Cloudflare, or even a simple web server. Most of these are free!
 
 ---
 


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for deploying a Blake-generated static site to GitHub Pages and updates the `README.md` to reflect these changes. The most important updates include the addition of the deployment workflow, instructions for configuring GitHub Pages, and a live demo link.

### Deployment Workflow:
* [`.github/workflows/deploy-pages.yml`](diffhunk://#diff-0f132b0962009071404990a6789b3466dbd8723d1f7b744f6aca0312396a7900R1-R55): Added a GitHub Actions workflow to automate deployment to GitHub Pages. This includes steps for setting up the .NET SDK, installing the Blake CLI, building the site, and publishing to the `gh-pages` branch.

### Documentation Updates:
* `README.md`:
  - Added a "Demo" section with a link to a live demo of the template.
  - Updated the "Deployment" section to explain the new GitHub Actions workflow, including setup steps for GitHub Pages and customization of the `base` tag in `index.html`.
  - Removed redundant hosting examples and emphasized GitHub Pages integration while mentioning other static hosting options.